### PR TITLE
Sync from Main to modifiedAlex

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,25 @@ The only items that are existing here are the markdown templates that need to be
 ### Usage
 For any periodic note (day, week, etc) you will need to save it a folder structure as such
 
-	Calendar>
-	Files>
-	Notes>
+	Calendar >
+	Files >
+	Notes >
 	Periodic Notes >
-			Daily Notes>
-			Weekly Notes> 
-			Quaterly Notes>
-			Monthly Notes>
-			Yearly notes>
+			1.Daily Notes >
+			2.Weekly Notes > 
+			3.Quaterly Notes >
+			4.Monthly Notes >
+			5.Yearly notes >
 
 This way the periodic notes can be tracked linearly.
 The days map from one to the next.
 
-Yesterday > Today > Tomorrow
+Yesterday -> Today -> Tomorrow
 
 And notes on areas or topics are saved separately in the files section.
 Periodic notes are based on the period of time they relate to and thus state objective facts about that opinion or feeling the author has about that period.
 
--  What did you do (tasks)
+- What did you do (tasks)
 - What did you Make (files created )
 - What did you want to do (things you wanted to achieve during the period and may contrast with the items that did in fact occur during that period).
 - How do you feel (any sections of reflection during any period greater than a week where simple task tracking becomes reductive)

--- a/Templater/Daily Note.md
+++ b/Templater/Daily Note.md
@@ -46,6 +46,7 @@ TASK
 WHERE completion = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>")
 WHERE text != ""
 
+Group By C.day
 ```
 # Past
 ## Remaining Tasks from Yesterday

--- a/Templater/Daily Note.md
+++ b/Templater/Daily Note.md
@@ -42,7 +42,6 @@ TASK
 WHERE completion = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>")
 WHERE text != ""
 
-
 ```
 # Past
 ## Remaining Tasks from Yesterday

--- a/Templater/Daily Note.md
+++ b/Templater/Daily Note.md
@@ -8,8 +8,8 @@ tags:
 linklist:
   - "[[<%tp.date.now("YYYY-[W]ww",0)%>]]"
 aliases:
-Totals.Done: 
-Totals.ToDo:
+Totals_Task-Done: 
+Totals_Task-ToDo:
 
 ---
 

--- a/Templater/Daily Note.md
+++ b/Templater/Daily Note.md
@@ -8,6 +8,9 @@ tags:
 linklist:
   - "[[<%tp.date.now("YYYY-[W]ww",0)%>]]"
 aliases:
+Totals.Done: 
+Totals.ToDo:
+
 ---
 
 Days: [[Periodic Notes/1.Daily Notes/<%tp.date.now("YYYY-MM-DD",-1,tp.file.title,"YYYY-MM-DD")%>|Yesterday]] <-- **[[<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>]]** --> [[Periodic Notes/1.Daily Notes/<%tp.date.now("YYYY-MM-DD",1,tp.file.title,"YYYY-MM-DD")%>|Tomorrow]]

--- a/Templater/Daily Note.md
+++ b/Templater/Daily Note.md
@@ -28,6 +28,7 @@ sort file.name asc
 ## ToDo
 #PeriodicToDo 
 <%tp.file.cursor()%>
+- [ ] #ToDo Update Tasks at [[End Of Day|EOD]] [created:: <%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>]
 ### Other File ToDo's
 ```dataview
 TASK

--- a/Templater/Monthly Note.md
+++ b/Templater/Monthly Note.md
@@ -24,7 +24,23 @@ aliases:
 
 ## Files Created
 
-## Tasks Done
+## Tasks
+```tracker
+searchType: frontmatter
+searchTarget: Totals_Task-Done, Totals_Task-ToDo
+folder: Periodic Notes/1.Daily Notes
+startDate: <% moment(tp.file.title, "YYYY-MM-DD").startOf("month").format("YYYY-MM-DD") %>
+endDate: <% moment(tp.file.title, "YYYY-MM-DD").endOf("month").format("YYYY-MM-DD") %>
 
-## Tasks Left
+datasetName: Totals_Task-Done, Totals_Task-ToDo
+
+line:
+	title: Tasks
+	yAxisLabel: Tasks in state
+	lineColor: green, red
+	showLegend: true
+```
+### Tasks Done
+
+### Tasks Left
 #PeriodicToDo

--- a/Templater/Person.md
+++ b/Templater/Person.md
@@ -1,0 +1,16 @@
+---
+creation Date: 2023-08-27 16:32
+tags:
+  - Person
+  - 2024-W05
+  - 2024-01-30
+  - Person
+FullName: 
+aliases: []
+linklist: []
+DoB: 
+DoD: 
+Age: 
+PersonalTitle:
+---
+<% tp.file.cursor() %>

--- a/Templater/Template toolkits.md
+++ b/Templater/Template toolkits.md
@@ -1,0 +1,63 @@
+This file covers the commands and components that are used in each template.
+This is based on the [Templater documentation](https://silentvoid13.github.io/Templater/introduction.html) which isn't great. 
+I've edited them a bit to be more useful, which requires a bit of fudging the functions. I'll define any functions that are used in the more complicated functions.
+# File
+## Insert Creation Date of the File
+You can specify the [[Date Format]] in the brackets.
+```shell
+<%tp.file.creation_date()%>
+```
+
+## Insert File Title
+```shell
+<%tp.file.title%>
+```
+# Date
+Insert the current date (date format, offset, reference string, reference string format)
+```shell
+<%tp.date.now("YYYY-MM-DD",0)%>
+<%tp.date.now("YYYY-MM-DD",0,"2023-01-DD","YYYY-MM-DD"%>
+```
+## Insert Yesterday's Date
+I use this in my [[Periodic Notes]] to refer to the last period (typically in a daily note). This works both for the current day and any date in the future or past. Using an exception by passing in the title of the file.
+```shell
+<%tp.date.now("YYYY-MM-DD",-1,tp.file.title,"YYYY-MM-DD")%>
+```
+This translates to.
+```
+current date in format "YYYY-MM-DD", -1 day, OR use the title of the file as a refrence string
+```
+The only issue is that the file will default to a generic note and not save to your [[Periodic Notes]] folder.
+To fix it you have to specify the path you want.
+```shell
+[[Periodic Notes/1.Daily Notes/<%tp.date.now("YYYY-MM-DD",-1,tp.file.title,"YYYY-MM-DD")%>|Yesterday]]
+```
+
+- [ ] #todo figure out how to do semantic referencing to next week etc  [created:: 2024-01-30]
+# Query
+All querys exist in a codeblock and require the dataview plugin.
+You also need to label the codeblock with the text 'dataview' next to opening 3 ` s (known as tylda key)
+## File Management
+This section fulfils the goal of identifying [[Notes Created]], one of the main use cases of [[Periodic Notes]]. This allows a true reflection of creation from a traceability view gives context to the tasks created that day.
+### Files Created during a Specified Date
+The following is intended for the use of periodic notes to list the files that were created during that date. This is useful as it allows future dates to be created ahead of time and still works. This currently only works for Daily notes as the [[#Insert File Title]] only inserts the title and would need more elaborate date handling to work for any other period.
+```dataview
+list
+WHERE file.cday = date("<%tp.file.title%>")
+sort file.name asc
+```
+## Task Management
+There is [[Tasks Meta Data]] that we can utilise in our query either using [[Dataview]] or using the [[Tasks Query]] system. 
+Note: Some of this [[Tasks Meta Data]] is implicit, but some needs to be toggled on in the Plugin settings.
+### Tasks Completed during a Specified Date
+This Query outputs the list of tasks that were marked as completed during a specified date.
+Note that this requires completion date to be turned on in settings. 
+This takes the current date as a reference unless the file title (the reference string) matches the "YYYY-MM-DD" syntax (the reference format)
+As an additional check any items where text is empty (the description of the task).
+You can additionally use `WHERE status = "X"` instead, but this is unnecessary if you have completion date turned on.
+```dataview
+TASK
+WHERE completion = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>")
+WHERE text != ""
+
+```

--- a/Templater/Template toolkits.md
+++ b/Templater/Template toolkits.md
@@ -25,7 +25,7 @@ I use this in my [[Periodic Notes]] to refer to the last period (typically in a 
 ```
 This translates to.
 ```
-current date in format "YYYY-MM-DD", -1 day, OR use the title of the file as a refrence string
+current date in format "YYYY-MM-DD", -1 day, OR use the title of the file as a refrence string which is in format "YYYY-MM-DD"
 ```
 The only issue is that the file will default to a generic note and not save to your [[Periodic Notes]] folder.
 To fix it you have to specify the path you want.

--- a/Templater/Template toolkits.md
+++ b/Templater/Template toolkits.md
@@ -41,7 +41,7 @@ You also need to label the codeblock with the text 'dataview' next to opening 3 
 This section fulfils the goal of identifying [[Notes Created]], one of the main use cases of [[Periodic Notes]]. This allows a true reflection of creation from a traceability view gives context to the tasks created that day.
 ### Files Created during a Specified Date
 The following is intended for the use of periodic notes to list the files that were created during that date. This is useful as it allows future dates to be created ahead of time and still works. This currently only works for Daily notes as the [[#Insert File Title]] only inserts the title and would need more elaborate date handling to work for any other period.
-```dataview
+```
 list
 WHERE file.cday = date("<%tp.file.title%>")
 sort file.name asc
@@ -55,7 +55,7 @@ Note that this requires completion date to be turned on in settings.
 This takes the current date as a reference unless the file title (the reference string) matches the "YYYY-MM-DD" syntax (the reference format)
 As an additional check any items where text is empty (the description of the task).
 You can additionally use `WHERE status = "X"` instead, but this is unnecessary if you have completion date turned on.
-```dataview
+```
 TASK
 WHERE completion = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>")
 WHERE text != ""

--- a/Templater/Template toolkits.md
+++ b/Templater/Template toolkits.md
@@ -33,7 +33,7 @@ To fix it you have to specify the path you want.
 [[Periodic Notes/1.Daily Notes/<%tp.date.now("YYYY-MM-DD",-1,tp.file.title,"YYYY-MM-DD")%>|Yesterday]]
 ```
 
-- [ ] #todo figure out how to do semantic referencing to next week etc  [created:: 2024-01-30]
+- [ ] #ToDo figure out how to do semantic referencing to next week etc  [created:: 2024-01-30]
 # Query
 All querys exist in a codeblock and require the dataview plugin.
 You also need to label the codeblock with the text 'dataview' next to opening 3 ` s (known as tylda key)

--- a/Templater/Weekly Note.md
+++ b/Templater/Weekly Note.md
@@ -20,6 +20,21 @@ list WHERE file.cday <= date("<% tp.date.weekday("YYYY-MM-DD", 6)%>") AND file.c
 ![[<% tp.date.weekday("YYYY-MM-DD", 4) %>#Stand Up]]
 # Tasks
 #PeriodicToDo 
+```tracker
+searchType: frontmatter
+searchTarget: Totals_Task-Done, Totals_Task-ToDo
+folder: Periodic Notes/1.Daily Notes
+startDate: <% tp.date.weekday("YYYY-MM-DD", 0) %>
+endDate: <% tp.date.weekday("YYYY-MM-DD", 6)%>
+
+datasetName: Totals_Task-Done, Totals_Task-ToDo
+
+line:
+	title: Tasks
+	yAxisLabel: Tasks in state
+	lineColor: green, red
+	showLegend: true
+```
 ## Remaining From This Week
 ```dataview
 TASK 

--- a/Templater/Weekly Note.md
+++ b/Templater/Weekly Note.md
@@ -20,7 +20,7 @@ list WHERE file.cday <= date("<% tp.date.weekday("YYYY-MM-DD", 6)%>") AND file.c
 ![[<% tp.date.weekday("YYYY-MM-DD", 4) %>#Stand Up]]
 # Tasks
 #PeriodicToDo 
-## Remaining From this Week
+## Remaining From This Week
 ```dataview
 TASK 
 WHERE status != "x"

--- a/Templater/Weekly Note.md
+++ b/Templater/Weekly Note.md
@@ -34,6 +34,8 @@ line:
 	yAxisLabel: Tasks in state
 	lineColor: green, red
 	showLegend: true
+	fillGap: true
+	legendPosition:
 ```
 ## Remaining From This Week
 ```dataview

--- a/Templater/Weekly Note.md
+++ b/Templater/Weekly Note.md
@@ -47,4 +47,5 @@ Group By file.name
 ```dataview
 TASK
 WHERE completion >= date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") AND completion <= date("<% tp.date.weekday("YYYY-MM-DD", 6)%>") WHERE text != ""
+Group By c.date
 ```


### PR DESCRIPTION
# Documentation
Template Toolkit
- Aim to allow clean documentation of templater functions and how they're used 

Readme Updates
- Added file structure expected 

# Added Functionality
- Noticed that the GroupBy function if broken will still run the count function but list normally. This bug adds the functionality to have a **task counter** on the querys that use it `group by c.date` is the way I default this. May change this in the future.
- `Totals` Data Category created
- `Totals_Task-Done` (to denote the total number of tasks done in a daily  note (updated at the end of a given day, generated at the beginning)
- `Totals_Task-ToDo` (to denote the total number of tasks to do in a daily note (updated at the end of a given day, generated at the beginning)
- [obsidian Tracker ](https://github.com/pyrochlore/obsidian-tracker) graph added
- `Totals_Task-Done` and `Totals_Task-ToDo` tracker added to the Weekly note
- `Totals_Task-Done` and `Totals_Task-ToDo` tracker added to the Monthly note
- Daily Note task created in template to update metadata at the end of the day

# Templates
- Person Template Added
