### PR TITLE
Release 1.1.0 

### DIFF
--- a/Templater/Daily Note.md
+++ b/Templater/Daily Note.md
@@ -1,4 +1,6 @@
 ---
+<%*const file = tp.file.find_tfile(moment(tp.file.title,"YYYY-MM-DD").subtract(1,'days').format("YYYY-MM-DD")); const fileCache = app.metadataCache.getFileCache(file); let Totals_Task_Done = 1; if (fileCache?.frontmatter["Totals_Task_Done"]) { Totals_Task_Done = fileCache.frontmatter["Totals_Task_Done"]; }-%>
+
 creation Date: <% tp.file.creation_date() %>
 tags:
   - Daily
@@ -7,18 +9,22 @@ tags:
 linklist:
   - '[[<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-[W]ww") %>]]'
 aliases: 
-Totals_Task-Done: 
-Totals_Task-ToDo: 
-Totals_Task-total: 
+Totals_Task_Done: <%Totals_Task_Done%>
+Totals_Task_ToDo: 
+Totals_Task_totals: 
 Daily_New_task:
 ---
-Days: [[Periodic Notes/1.Daily Notes/<% moment(tp.file.title, "YYYY-MM-DD").subtract(1,'days').format("YYYY-MM-DD") %>|Yesterday]] <-- **[[<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>]]** --> [[Periodic Notes/1.Daily Notes/<% moment(tp.file.title, "YYYY-MM-DD").add(1,'days').format("YYYY-MM-DD") %>|Tomorrow]]
 
 # Today
 ## Stand Up
 >*<% moment(tp.file.title, "YYYY-MM-DD").format("dddd") %>*
 > 
 > 
+
+
+
+
+<%Totals_Task_Done%>
 
 ## Change Log
 Created Today:

--- a/Templater/Daily Note.md
+++ b/Templater/Daily Note.md
@@ -3,23 +3,23 @@ creation Date: <% tp.file.creation_date() %>
 tags:
   - Daily
   - <%tp.file.title%>
-  - <% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-[W]ww") %>
-
+  - <%moment(tp.file.title,"YYYY-MM-DD").format("YYYY-[W]ww")%>
 linklist:
-  - "[[<%tp.date.now("YYYY-[W]ww",0)%>]]"
-aliases:
+  - '[[<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-[W]ww") %>]]'
+aliases: 
 Totals_Task-Done: 
-Totals_Task-ToDo:
-Totals_Task-total:
+Totals_Task-ToDo: 
+Totals_Task-total: 
 Daily_New_task:
 ---
-
-Days: [[Periodic Notes/1.Daily Notes/<%tp.date.now("YYYY-MM-DD",-1,tp.file.title,"YYYY-MM-DD")%>|Yesterday]] <-- **[[<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>]]** --> [[Periodic Notes/1.Daily Notes/<%tp.date.now("YYYY-MM-DD",1,tp.file.title,"YYYY-MM-DD")%>|Tomorrow]]
+Days: [[Periodic Notes/1.Daily Notes/<% moment(tp.file.title, "YYYY-MM-DD").subtract(1,'days').format("YYYY-MM-DD") %>|Yesterday]] <-- **[[<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>]]** --> [[Periodic Notes/1.Daily Notes/<% moment(tp.file.title, "YYYY-MM-DD").add(1,'days').format("YYYY-MM-DD") %>|Tomorrow]]
 
 # Today
 ## Stand Up
-> *<%tp.date.now("dddd",0,tp.file.title,"YYYY-MM-DD")%>*
+>*<% moment(tp.file.title, "YYYY-MM-DD").format("dddd") %>*
 > 
+> 
+
 ## Change Log
 Created Today:
 ```dataview
@@ -33,42 +33,48 @@ list
 WHERE file.mday = date("<%tp.file.title%>") AND file.cday != date("<%tp.file.title%>")
 sort file.name asc
 ```
+
 ## ToDo
 #PeriodicToDo 
-- [ ] #ToDo Update Tasks at [[End Of Day|EOD]] [created:: <%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>]
+- [ ] #ToDo Update Tasks at [[End Of Day|EOD]] [created:: <% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>]
+
 ### Other File ToDo's
 ```dataview
 TASK
-WHERE created = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>") OR start = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>") OR scheduled = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>") OR due = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>")
+WHERE created = date("<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>") OR start = date("<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>") OR scheduled = date("<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>") OR due = date("<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>")
 WHERE status != "x" AND status != "-"
 WHERE file.name != "<%tp.file.title%>"
 WHERE text != "" AND text != "-"
 
 SORT priority DESC
 ```
+
 ## Done
 ### Completed Today
 ```dataview
 TASK
-WHERE completion = date("<%tp.date.now("YYYY-MM-DD",0,tp.file.title,"YYYY-MM-DD")%>")
+WHERE completion = date("<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>")
 WHERE text != ""
 
 Group By C.day
 ```
+
 # Past
+
 ## Remaining Tasks from Yesterday
 ```dataview
 TASK
 WHERE status != "x" AND status != "-"
-WHERE created = date("<%tp.date.now("YYYY-MM-DD",-1,tp.file.title,"YYYY-MM-DD")%>") OR start = date("<%tp.date.now("YYYY-MM-DD",-1,tp.file.title,"YYYY-MM-DD")%>") OR scheduled = date("<%tp.date.now("YYYY-MM-DD",-1,tp.file.title,"YYYY-MM-DD")%>")
+WHERE created = date("<% moment(tp.file.title, "YYYY-MM-DD").subtract(1,'days').format("YYYY-MM-DD") %>") OR start = date("<% moment(tp.file.title, "YYYY-MM-DD").subtract(1,'days').format("YYYY-MM-DD") %>") OR scheduled = date("<% moment(tp.file.title, "YYYY-MM-DD").subtract(1,'days').format("YYYY-MM-DD") %>")
 WHERE text != ""
 
 SORT priority DESC
 ```
+
 ## Remaining Tasks from past Week
 ```dataview
 TASK
-WHERE created >= date("<%tp.date.now("YYYY-MM-DD",-7,tp.file.title,"YYYY-MM-DD")%>") and created <= date("<%tp.date.now("YYYY-MM-DD",-2,tp.file.title,"YYYY-MM-DD")%>") OR start >= date("<%tp.date.now("YYYY-MM-DD",-7,tp.file.title,"YYYY-MM-DD")%>") and start <= date("<%tp.date.now("YYYY-MM-DD",-2,tp.file.title,"YYYY-MM-DD")%>") OR scheduled >= date("<%tp.date.now("YYYY-MM-DD",-7,tp.file.title,"YYYY-MM-DD")%>") and scheduled <= date("<%tp.date.now("YYYY-MM-DD",-2,tp.file.title,"YYYY-MM-DD")%>")
+WHERE created >= date("<% moment(tp.file.title, "YYYY-MM-DD").startOf('week').format("YYYY-MM-DD") %>") and created <= date("<% moment(tp.file.title, "YYYY-MM-DD").endOf('week').format("YYYY-MM-DD") %>") OR start >= date("<% moment(tp.file.title, "YYYY-MM-DD").startOf('week').format("YYYY-MM-DD") %>") and start <= date("<% moment(tp.file.title, "YYYY-MM-DD").endOf('week').format("YYYY-MM-DD") %>") OR scheduled >= date("<% moment(tp.file.title, "YYYY-MM-DD").startOf('week').format("YYYY-MM-DD") %>") and scheduled <= date("<% moment(tp.file.title, "YYYY-MM-DD").endOf('week').format("YYYY-MM-DD") %>")
 WHERE file.name != "<%tp.file.title%>"
 WHERE status != "x" AND status != "-"
 WHERE text != ""
@@ -76,4 +82,3 @@ WHERE text != ""
 GROUP BY file.name
 SORT created DESC
 ```
-

--- a/Templater/Monthly Note.md
+++ b/Templater/Monthly Note.md
@@ -42,7 +42,20 @@ line:
 	showLegend: true
 ```
 
-### Tasks Done
-
 ### Tasks Left
-#PeriodicToDo
+#PeriodicToDo 
+```dataview
+TASK 
+WHERE status != "x"
+WHERE created >= date("<%moment(tp.file.title,"YYYY-[M]MM").startOf('month').format("YYYY-MM-DD")%>") AND created <= date("<%moment(tp.file.title,"YYYY-[M]MM").endOf('month').format("YYYY-MM-DD")%>") 
+WHERE text != ""
+Group By file.name 
+```
+z
+### Tasks Done
+```dataview
+TASK
+WHERE completion >= date("<%moment(tp.file.title,"YYYY-[M]MM").startOf('month').format("YYYY-MM-DD")%>") AND completion <= date("<%moment(tp.file.title,"YYYY-[M]MM").endOf('month').format("YYYY-MM-DD")%>") WHERE text != ""
+Group By c.date
+```
+

--- a/Templater/Monthly Note.md
+++ b/Templater/Monthly Note.md
@@ -3,17 +3,18 @@ creation Date: <% tp.file.creation_date() %>
 tags:
   - MonthlyNote
   - <%tp.file.title%>
-  - <%tp.date.now("MMMM",0)%>
-  - <%tp.date.now("YYYY",0)%>
-  - <%tp.date.now("YYYY-[Q]Q",0)%>
+  - <%moment(tp.file.title,"YYYY-[M]MM").format("MMMM")%>
+  - <%moment(tp.file.title,"YYYY-[M]MM").format("YYYY")%>
+  - <%moment(tp.file.title,"YYYY-[M]mm").format("YYYY-[Q]Q")%>
 linklist:
   - "[[ChangeLog]]"
-  - "[[<%tp.date.now("YYYY-[Q]Q",0)%>]]"
+  - "[[<%moment(tp.file.title,"YYYY-[M]MM").format("YYYY-[Q]QQ")%>]]"
 aliases:
-  - <%tp.date.now("MMMM",0)%>
-  - <%tp.date.now("MMMM YYYY",0)%>
-  - <%tp.date.now("YYYY MMMM",0)%>
+  - <%moment(tp.file.title,"YYYY-[M]MM").format("MMMM")%>
+  - <%moment(tp.file.title,"YYYY-[M]MM").format("MMMM YYYY")%>
+  - <%moment(tp.file.title,"YYYY-[M]MM").format("YYYY MMMM")%>
 ---
+
 # Thoughts
 
 ## What Happened
@@ -23,7 +24,6 @@ aliases:
 # Facts
 
 ## Files Created
-
 ## Tasks
 ```tracker
 searchType: frontmatter
@@ -41,6 +41,7 @@ line:
 	fillGap: true
 	showLegend: true
 ```
+
 ### Tasks Done
 
 ### Tasks Left

--- a/Templater/Monthly Note.md
+++ b/Templater/Monthly Note.md
@@ -8,8 +8,7 @@ tags:
   - <%moment(tp.file.title,"YYYY-[M]mm").format("YYYY-[Q]Q")%>
 linklist:
   - "[[ChangeLog]]"
-  - '[[Periodic Notes/4.Quarterly Notes/<% moment(tp.file.title, "YYYY").format("YYYY-[Q]QQ") %>|<% moment(tp.file.title, "YYYY").format("YYYY-[Q]QQ") %>]]'
-
+  - '[[Periodic Notes/4.Quarterly Notes/<% moment(tp.file.title, "YYYY-[M]MM").format("YYYY-[Q]Q") %>|<% moment(tp.file.title, "YYYY-[M]MM").format("YYYY-[Q]Q") %>]]'
 aliases:
   - <%moment(tp.file.title,"YYYY-[M]MM").format("MMMM")%>
   - <%moment(tp.file.title,"YYYY-[M]MM").format("MMMM YYYY")%>
@@ -56,7 +55,6 @@ WHERE created >= date("<%moment(tp.file.title,"YYYY-[M]MM").startOf('month').for
 WHERE text != ""
 Group By file.name 
 ```
-z
 ### Tasks Done
 ```dataview
 TASK

--- a/Templater/Monthly Note.md
+++ b/Templater/Monthly Note.md
@@ -31,12 +31,12 @@ aliases:
 ## Tasks
 ```tracker
 searchType: frontmatter
-searchTarget: Totals_Task-Done, Totals_Task-ToDo
+searchTarget: Totals_Task_Done, Totals_Task_ToDo
 folder: Periodic Notes/1.Daily Notes
 startDate: <% moment(tp.file.title, "YYYY-[M]MM").startOf("month").format("YYYY-MM-DD") %>
 endDate: <% moment(tp.file.title, "YYYY-[M]MM").endOf("month").format("YYYY-MM-DD") %>
 
-datasetName: Totals_Task-Done, Totals_Task-ToDo
+datasetName: Totals_Task_Done, Totals_Task_ToDo
 
 line:
 	title: Tasks

--- a/Templater/Monthly Note.md
+++ b/Templater/Monthly Note.md
@@ -8,12 +8,17 @@ tags:
   - <%moment(tp.file.title,"YYYY-[M]mm").format("YYYY-[Q]Q")%>
 linklist:
   - "[[ChangeLog]]"
-  - "[[<%moment(tp.file.title,"YYYY-[M]MM").format("YYYY-[Q]QQ")%>]]"
+  - '[[Periodic Notes/4.Quarterly Notes/<% moment(tp.file.title, "YYYY").format("YYYY-[Q]QQ") %>|<% moment(tp.file.title, "YYYY").format("YYYY-[Q]QQ") %>]]'
+
 aliases:
   - <%moment(tp.file.title,"YYYY-[M]MM").format("MMMM")%>
   - <%moment(tp.file.title,"YYYY-[M]MM").format("MMMM YYYY")%>
   - <%moment(tp.file.title,"YYYY-[M]MM").format("YYYY MMMM")%>
 ---
+[[Periodic Notes/3.Monthly Notes/<%moment(tp.file.title,"YYYY-[M]MM").subtract(1,'months').format("YYYY-[M]MM")%>|Last Month]] 
+
+
+[[Periodic Notes/3.Monthly Notes/<%moment(tp.file.title,"YYYY-[M]MM").add(1,'months').format("YYYY-[M]MM")%>|Next Month]]
 
 # Thoughts
 
@@ -29,8 +34,8 @@ aliases:
 searchType: frontmatter
 searchTarget: Totals_Task-Done, Totals_Task-ToDo
 folder: Periodic Notes/1.Daily Notes
-startDate: <% moment(tp.file.title, "YYYY-MM-DD").startOf("month").format("YYYY-MM-DD") %>
-endDate: <% moment(tp.file.title, "YYYY-MM-DD").endOf("month").format("YYYY-MM-DD") %>
+startDate: <% moment(tp.file.title, "YYYY-[M]MM").startOf("month").format("YYYY-MM-DD") %>
+endDate: <% moment(tp.file.title, "YYYY-[M]MM").endOf("month").format("YYYY-MM-DD") %>
 
 datasetName: Totals_Task-Done, Totals_Task-ToDo
 
@@ -58,4 +63,3 @@ TASK
 WHERE completion >= date("<%moment(tp.file.title,"YYYY-[M]MM").startOf('month').format("YYYY-MM-DD")%>") AND completion <= date("<%moment(tp.file.title,"YYYY-[M]MM").endOf('month').format("YYYY-MM-DD")%>") WHERE text != ""
 Group By c.date
 ```
-

--- a/Templater/Quarterly Note.md
+++ b/Templater/Quarterly Note.md
@@ -3,16 +3,20 @@ creation Date: <% tp.file.creation_date() %>
 tags:
   - MonthlyNote
   - <%tp.file.title%>
-  - <%tp.date.now("MMMM",0)%>
-  - <%tp.date.now("YYYY",0)%>
 linklist:
   - "[[ChangeLog]]"
-  - "[[<%tp.date.now("YYYY",0)%>]]"
+  - '[[<%moment(tp.file.title,"YYYY-[M]MM").format("YYYY")%>]]'
 aliases:
-  - <%tp.date.now("MMMM",0)%>
+  - <%tp.file.title%>
   - <%tp.date.now("MMMM YYYY",0)%>
   - <%tp.date.now("YYYY MMMM",0)%>
 ---
+
+[[Periodic Notes/4.Quarterly Notes/<%moment(tp.file.title,"YYYY-[Q]Q").subtract(1,'Q').format("YYYY-[Q]Q")%>|Last Month]] 
+
+
+[[Periodic Notes/4.Quarterly Notes/<%moment(tp.file.title,"YYYY-[Q]Q").add(1,'Q').format("YYYY-[Q]Q")%>|Next Month]]
+
 # Thoughts
 
 ## What Happened

--- a/Templater/Weekly Note.md
+++ b/Templater/Weekly Note.md
@@ -1,5 +1,5 @@
 ---
-creation Date: <% tp.file.creation_date() %>
+creation Date: <%tp.file.creation_date()%>
 tags:
   - WeeklyNote
   - <%tp.file.title%>
@@ -21,7 +21,7 @@ list WHERE file.cday <= date("<%moment(tp.file.title,"YYYY-[W]ww").endOf('week')
 Modified (May change with later modifications):
 ```dataview
 list 
-WHERE (file.mday <= date("<%moment(tp.file.title,"YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>") AND file.mday >= date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>")) AND (file.cday != (date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") OR date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(1,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(2,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(3,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(4,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(5,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(6,'days').format("YYYY-MM-DD")%>")))
+WHERE (file.mday <= date("<%moment(tp.file.title,"YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>") AND file.mday >= date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>")) AND (file.cday != (date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") OR date("<% tp.date.weekday("YYYY-MM-DD", 0)%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(1,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(2,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(3,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(4,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(5,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(6,'days').format("YYYY-MM-DD")%>")))
 
 sort file.name asc
 ```
@@ -34,7 +34,7 @@ searchType: frontmatter
 searchTarget: Totals_Task-Done, Totals_Task-ToDo,Totals_Task-total,Daily_New_task
 folder: Periodic Notes/1.Daily Notes
 startDate: <%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>
-endDate: <% moment(tp.file.title, "YYYY-[W]ww").endOf('week').format("YYYY-MM-DD") %>
+endDate: <%moment(tp.file.title, "YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>
 
 datasetName: Done,ToDo,total,new
 

--- a/Templater/Weekly Note.md
+++ b/Templater/Weekly Note.md
@@ -31,7 +31,7 @@ sort file.name asc
 #PeriodicToDo 
 ```tracker
 searchType: frontmatter
-searchTarget: Totals_Task-Done, Totals_Task-ToDo,Totals_Task-total,Daily_New_task
+searchTarget: Totals_Task_Done, Totals_Task_ToDo,Totals_Task_totals,Daily_New_task
 folder: Periodic Notes/1.Daily Notes
 startDate: <%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>
 endDate: <%moment(tp.file.title, "YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>

--- a/Templater/Weekly Note.md
+++ b/Templater/Weekly Note.md
@@ -4,35 +4,37 @@ tags:
   - WeeklyNote
   - <%tp.file.title%>
 linklist:
-  - "[[<%tp.date.now("YYYY-[M]MM",0)%>]]"
+  - '[[<%moment(tp.file.title,"YYYY-[W]ww").format("YYYY-[M]MM")%>]]'
 aliases:
 ---
-# ChangLog
+<%moment(tp.file.title,"YYYY-[W]ww").format("YYYY-MM-DD")%>
+
+# ChangLog "
 Created:
+<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>
+
+<%moment(tp.file.title,"YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>
+
 ```dataview
-list WHERE file.cday <= date("<% tp.date.weekday("YYYY-MM-DD", 6)%>") AND file.cday >= date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") sort file.name asc
+list WHERE file.cday <= date("<%moment(tp.file.title,"YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>") AND file.cday >= date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") sort file.name asc
 ```
 Modified (May change with later modifications):
 ```dataview
 list 
-WHERE (file.mday <= date("<% tp.date.weekday("YYYY-MM-DD", 6)%>") AND file.mday >= date("<% tp.date.weekday("YYYY-MM-DD", 0) %>")) AND (file.cday != (date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") OR date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") OR date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") OR date("<% tp.date.weekday("YYYY-MM-DD", 1) %>") OR date("<% tp.date.weekday("YYYY-MM-DD", 2) %>") OR date("<% tp.date.weekday("YYYY-MM-DD", 3) %>") OR date("<% tp.date.weekday("YYYY-MM-DD", 4) %>") OR date("<% tp.date.weekday("YYYY-MM-DD", 5) %>") OR date("<% tp.date.weekday("YYYY-MM-DD", 6) %>")))
+WHERE (file.mday <= date("<%moment(tp.file.title,"YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>") AND file.mday >= date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>")) AND (file.cday != (date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") OR date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(1,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(2,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(3,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(4,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(5,'days').format("YYYY-MM-DD")%>") OR date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').add(6,'days').format("YYYY-MM-DD")%>")))
 
 sort file.name asc
 ```
+
 # What Happened
-![[<% tp.date.weekday("YYYY-MM-DD", 0) %>#Stand Up]]
-![[<% tp.date.weekday("YYYY-MM-DD", 1) %>#Stand Up]]
-![[<% tp.date.weekday("YYYY-MM-DD", 2) %>#Stand Up]]
-![[<% tp.date.weekday("YYYY-MM-DD", 3) %>#Stand Up]]
-![[<% tp.date.weekday("YYYY-MM-DD", 4) %>#Stand Up]]
 # Tasks
 #PeriodicToDo 
 ```tracker
 searchType: frontmatter
 searchTarget: Totals_Task-Done, Totals_Task-ToDo,Totals_Task-total,Daily_New_task
 folder: Periodic Notes/1.Daily Notes
-startDate: <% tp.date.weekday("YYYY-MM-DD", 0) %>
-endDate: <% tp.date.weekday("YYYY-MM-DD", 6)%>
+startDate: <%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>
+endDate: <% moment(tp.file.title, "YYYY-[W]ww").endOf('week').format("YYYY-MM-DD") %>
 
 datasetName: Done,ToDo,total,new
 
@@ -44,17 +46,19 @@ line:
 	fillGap: true
 	legendPosition:
 ```
+
 ## Remaining From This Week
 ```dataview
 TASK 
 WHERE status != "x"
-WHERE created >= date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") AND created <= date("<% tp.date.weekday("YYYY-MM-DD", 6)%>") 
+WHERE created >= date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") AND created <= date("<%moment(tp.file.title,"YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>") 
 WHERE text != ""
 Group By file.name 
 ```
+
 ## Done
 ```dataview
 TASK
-WHERE completion >= date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") AND completion <= date("<% tp.date.weekday("YYYY-MM-DD", 6)%>") WHERE text != ""
+WHERE completion >= date("<%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>") AND completion <= date("<%moment(tp.file.title,"YYYY-[W]ww").endOf('week').format("YYYY-MM-DD")%>") WHERE text != ""
 Group By c.date
 ```

--- a/Templater/Weekly Note.md
+++ b/Templater/Weekly Note.md
@@ -9,7 +9,7 @@ aliases:
 ---
 <%moment(tp.file.title,"YYYY-[W]ww").format("YYYY-MM-DD")%>
 
-# ChangLog "
+# ChangLog
 Created:
 <%moment(tp.file.title,"YYYY-[W]ww").startOf('week').format("YYYY-MM-DD")%>
 

--- a/Templater/Yearly Note.md
+++ b/Templater/Yearly Note.md
@@ -3,14 +3,14 @@ creation Date: <% tp.file.creation_date() %>
 tags:
   - MonthlyNote
   - <%tp.file.title%>
-  - <%tp.date.now("YYYY",0)%>
 linklist:
-  - "[[Periodic Notes/Yearly Notes/<%tp.date.now("YYYY",-1,tp.file.title,"YYYY")%>|<%tp.date.now("YYYY",-1,tp.file.title,"YYYY")%>]]"
-  - "[[Periodic Notes/Yearly Notes/<%tp.date.now("YYYY",0,tp.file.title,"YYYY")%>|<%tp.date.now("YYYY",0,tp.file.title,"YYYY")%>]]"
-  - "[[Periodic Notes/Yearly Notes/<%tp.date.now("YYYY",+1,tp.file.title,"YYYY")%>|<%tp.date.now("YYYY",365,tp.file.title,"YYYY")%>]]"
+  - "[[Periodic Notes/5.Yearly Notes/<% moment(tp.file.title, "YYYY").subtract(1,'years').format("YYYY") %>|<% moment(tp.file.title, "YYYY").subtract(1,'years').format("YYYY") %>]]"
+  - "[[Periodic Notes/5.Yearly Notes/<%tp.file.title%>|<%tp.file.title%>]]"
+  - "[[Periodic Notes/5.Yearly Notes/<% moment(tp.file.title, "YYYY").add(1,'years').format("YYYY") %>|<% moment(tp.file.title, "YYYY").add(1,'years').format("YYYY") %>]]"
 aliases:
 
 ---
+
 # Thoughts
 
 ## What Happened
@@ -18,13 +18,27 @@ aliases:
 ## What's Next
 
 # Facts
+<% moment(tp.file.title, "YYYY").startOf('year').format("YYYY-MM-DD") %>
+<% moment(tp.file.title, "YYYY-MM-DD").endOf('week').format("YYYY-MM-DD") %>
 
 ## Files Created
 ```dataview
-list WHERE file.cday <= date("<% tp.date.weekday("YYYY-MM-DD", 6)%>") AND file.cday >= date("<% tp.date.weekday("YYYY-MM-DD", 0) %>") sort file.name asc
+list WHERE file.cday <= date("<% moment(tp.file.title, "YYYY-MM-DD").endOf('week').format("YYYY-MM-DD") %>") AND file.cday >= date("<% moment(tp.file.title, "YYYY").startOf('year').format("YYYY-MM-DD") %>") sort file.name asc
 ```
 
 ## Tasks Done
+```dataview
+TASK
+WHERE completion >= date("<%moment(tp.file.title,"YYYY").startOf('year').format("YYYY-MM-DD")%>") AND completion <= date("<%moment(tp.file.title,"YYYY").endOf('year').format("YYYY-MM-DD")%>") WHERE text != ""
+Group By c.date
+```
 
 ## Tasks Left
 #PeriodicToDo 
+```dataview
+TASK 
+WHERE status != "x"
+WHERE created >= date("<%moment(tp.file.title,"YYYY").startOf('year').format("YYYY-MM-DD")%>") AND created <= date("<%moment(tp.file.title,"YYYY").endOf('year').format("YYYY-MM-DD")%>") 
+WHERE text != ""
+Group By file.name 
+```

--- a/Templater/Yearly Note.md
+++ b/Templater/Yearly Note.md
@@ -23,7 +23,7 @@ aliases:
 
 ## Files Created
 ```dataview
-list WHERE file.cday <= date("<% moment(tp.file.title, "YYYY-MM-DD").endOf('week').format("YYYY-MM-DD") %>") AND file.cday >= date("<% moment(tp.file.title, "YYYY").startOf('year').format("YYYY-MM-DD") %>") sort file.name asc
+list WHERE file.cday <= date("<% moment(tp.file.title, "YYYY").endOf('year').format("YYYY-MM-DD") %>") AND file.cday >= date("<% moment(tp.file.title, "YYYY").startOf('year').format("YYYY-MM-DD") %>") sort file.name asc
 ```
 
 ## Tasks Done

--- a/Templater/moment.js test.md
+++ b/Templater/moment.js test.md
@@ -14,3 +14,16 @@ Passing a date in and modifying format
 <% moment("2024-03-06", "YYYY-MM-DD").format("YYYY-MM") %>
 
 Results of experimenting ![[Pasted image 20240306160122.png]]
+
+---
+<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-[W]ww") %>
+
+<% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>
+
+subtract / add
+<% moment(tp.file.title, "YYYY-MM-DD").subtract(1,'days').format("YYYY-MM-DD") %>
+<% moment(tp.file.title, "YYYY-MM-DD").add(1,'days').format("YYYY-MM-DD") %>
+
+start of/ end of
+<% moment(tp.file.title, "YYYY-MM-DD").startOf('week').format("YYYY-MM-DD") %>
+<% moment(tp.file.title, "YYYY-MM-DD").endOf('week').format("YYYY-MM-DD") %>


### PR DESCRIPTION

# New Stuff
- Monthly notes now has DataView Task trackers for remaining and done
- Daily note not have automated variable that read the frontmatter of yesterdays note
- Data Points
# Improvements Stuff
- Removed the Semantic links to yesterday and tommorow in the daily note as it forced days to follow each other without cause and introduced additioal maintenance to be required, this was thus removed from the default.

```
Days: Yesterday <- Today -> Tommorow
```


# Data Points
## New

## Changes
- Totals_Task-Done has changed to Totals_Task_Done
- Totals_Task-ToDo has changed to Toatls_Task_ToDo
- 